### PR TITLE
fix ci problem and revert koa-views version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,11 +1033,11 @@
       "dev": true
     },
     "consolidate": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.16.0.tgz",
-      "integrity": "sha512-Nhl1wzCslqXYTJVDyJCu3ODohy9OfBMB5uD2BiBTzd7w+QY0lBzafkR8y8755yMYHAaMD4NuzbAw03/xzfw+eQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
+      "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
       "requires": {
-        "bluebird": "^3.7.2"
+        "bluebird": "^3.1.1"
       }
     },
     "constantinople": {
@@ -2500,17 +2500,16 @@
       }
     },
     "koa-views": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/koa-views/-/koa-views-7.0.0.tgz",
-      "integrity": "sha512-I9H2Dood5MhwzmWk7hkWuxEBObd3uv/4eEPJP2r43Ro+rK8ICKjrIKEzKrfT89JNX69vWOEU8JreJwRjb5HOFw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/koa-views/-/koa-views-6.3.1.tgz",
+      "integrity": "sha512-weIaPs2cCHWT2qK8qHRmwlZ29xRCvUVy1v/z12AGavVV5j4QIU0W/Y7OVBBu1sTkcO9dDJ25ajGYHGZ/aY43IQ==",
       "requires": {
-        "consolidate": "^0.16.0",
+        "consolidate": "0.15.1",
         "debug": "^4.1.0",
         "get-paths": "0.0.7",
         "koa-send": "^5.0.0",
         "mz": "^2.4.0",
-        "pretty": "^2.0.0",
-        "resolve-path": "^1.4.0"
+        "pretty": "^2.0.0"
       }
     },
     "koa2-connect": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "node dist/bin/server.js",
-    "test": "echo \"Information: no test specified\" && exit 0",
+    "test": "echo \"Information: no test specified\"",
     "build": "bash scripts/build.sh",
     "update-static": "bash scripts/update-static.sh"
   },
@@ -20,7 +20,7 @@
     "koa-logger": "^3.2.0",
     "koa-router": "^10.0.0",
     "koa-static": "^5.0.0",
-    "koa-views": "^7.0.0",
+    "koa-views": "^6.3.1",
     "koa2-connect": "^1.0.2",
     "minimalistic-assert": "^1.0.1",
     "pug": "^3.0.1",


### PR DESCRIPTION
koa-views 7.0.0 breaks the build, reverting to 6.3.1
fix nodejs-ci not emitting errors as designed