### PR TITLE
fix buffer issue -> diff hash on win and linux

### DIFF
--- a/lib/pow/solver.ts
+++ b/lib/pow/solver.ts
@@ -11,7 +11,7 @@ class Solver {
     let nonce = await utils.allocBuffer(NONCE_SIZE)
     for (;;) {
       await this._genNonce(nonce)
-      const hash = await utils.hash(nonce, Buffer.from(prefix, 'hex'))
+      const hash = await utils.hash(nonce, prefix)
       if (await utils.checkComplexity(hash, complexity)) {
         return nonce
       }

--- a/lib/pow/utils.ts
+++ b/lib/pow/utils.ts
@@ -23,9 +23,9 @@ const readTimestamp = async (buffer: Buffer, off: number) => {
   return buffer.readUInt32BE(off) * 0x100000000 + buffer.readUInt32BE(off + 4)
 }
 
-const hash = async (nonce: Buffer, prefix: Buffer | undefined) => {
+const hash = async (nonce: Buffer, prefix: string) => {
   const h = createHash('sha256')
-  if (prefix) h.update(prefix)
+  if (prefix) h.update(prefix,'hex')
   h.update(nonce)
   return h.digest()
 }

--- a/lib/pow/verifier.ts
+++ b/lib/pow/verifier.ts
@@ -26,7 +26,7 @@ export class Verifier {
     const ts = await utils.readTimestamp(nonce, 0)
     const now = Date.now()
     if (Math.abs(ts - now) > this.validity) return false
-    const hash = await utils.hash(nonce, Buffer.from(prefix, 'hex'))
+    const hash = await utils.hash(nonce, prefix)
     if (!(await utils.checkComplexity(hash, complexity))) return false
     return true
   }


### PR DESCRIPTION
buffer produces different hash when reading a hex string despite the 'hex' option is specified. remove all possible occurrences, not clear whether it's module / node version or OS issue